### PR TITLE
Fix: missing scrapy_playwright

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pycryptodome==3.20.0
 scrapoxy==2.0.2
 Scrapy==2.11.2
-playright_python
+scrapy_playwright

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pycryptodome==3.20.0
 scrapoxy==2.0.2
 Scrapy==2.11.2
-git+https://github.com/microsoft/playwright-python.git
+playright_python


### PR DESCRIPTION
We should be pulling playright_python from PyPI via pip not the git+ from a Microsoft repository.

This was discovered during the Workshop at the Ubuntu Summit 2024.